### PR TITLE
Add optional sensor summary view in sources

### DIFF
--- a/app/monitoring_sensor/schemas.py
+++ b/app/monitoring_sensor/schemas.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List
+from app.monitoring_sensor_fields.schemas import MonitoringSensorField, MonitoringSensorFieldName
 from uuid import UUID
 from datetime import datetime
 
@@ -31,3 +32,19 @@ class MonitoringSensor(MonitoringSensorBase):
 
     class Config:
         orm_mode = True
+
+
+class MonitoringSensorWithFields(MonitoringSensor):
+    fields: List[MonitoringSensorField] = []
+
+
+class MonitoringSensorName(BaseModel):
+    id: UUID
+    sensor_name: str
+
+    class Config:
+        orm_mode = True
+
+
+class MonitoringSensorNameWithFields(MonitoringSensorName):
+    fields: List[MonitoringSensorFieldName] = []

--- a/app/monitoring_sensor_fields/schemas.py
+++ b/app/monitoring_sensor_fields/schemas.py
@@ -24,3 +24,11 @@ class MonitoringSensorField(MonitoringSensorFieldBase):
 
     class Config:
         orm_mode = True
+
+
+class MonitoringSensorFieldName(BaseModel):
+    id: UUID
+    field_name: str
+
+    class Config:
+        orm_mode = True

--- a/app/monitoring_source/schemas.py
+++ b/app/monitoring_source/schemas.py
@@ -1,7 +1,11 @@
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List
 from uuid import UUID
 from datetime import datetime
+from app.monitoring_sensor.schemas import (
+    MonitoringSensorWithFields,
+    MonitoringSensorNameWithFields,
+)
 
 class SourceBase(BaseModel):
     mon_loc_id: Optional[UUID] = None
@@ -45,3 +49,11 @@ class Source(SourceBase):
 
     class Config:
         from_attributes  = True
+
+
+class SourceWithSensors(Source):
+    sensors: Optional[List[MonitoringSensorWithFields]] = None
+
+
+class SourceWithSensorNames(Source):
+    sensors: Optional[List[MonitoringSensorNameWithFields]] = None

--- a/app/monitoring_source/services.py
+++ b/app/monitoring_source/services.py
@@ -1,8 +1,13 @@
-from typing import Optional
+from typing import Optional, List
 from app.monitoring_source.models import Source
 from app.monitoring_source import schemas, selectors
+from app.monitoring_sensor_fields.schemas import (
+    MonitoringSensorField,
+    MonitoringSensorFieldName,
+)
 from sqlalchemy.orm import Session
 from uuid import UUID
+from app.monitoring_sensor import services as sensor_services
 
 def create_source(db: Session, payload: schemas.SourceCreate) -> Source:
     obj = Source(**payload.dict())
@@ -27,7 +32,11 @@ def delete_source(db: Session, source_id: UUID) -> None:
         db.delete(obj)
         db.commit()
 
-def enrich_source(source: Source) -> dict:
+def enrich_source(
+    source: Source,
+    children: bool = False,
+    minimal: bool = False,
+) -> dict:
     details = None
     if source.mon_loc and source.mon_loc.project:
         details = schemas.SourceMetadata(
@@ -39,7 +48,33 @@ def enrich_source(source: Source) -> dict:
         )
 
     # Bypass validation because we already know the model is valid
-    source_dict = dict(source.__dict__)  # make a copy
-    source_dict["details"] = details  # add the extra field
-    source_model = schemas.Source.model_construct(**source_dict)
+    source_dict = dict(source.__dict__)
+    source_dict["details"] = details
+
+    if children:
+        sensors: List[dict] = []
+        for sensor in source.mon_sensors:
+            if minimal:
+                sensor_dict = {
+                    "id": sensor.id,
+                    "sensor_name": sensor.sensor_name,
+                    "fields": [
+                        {"id": f.id, "field_name": f.field_name} for f in sensor.fields
+                    ],
+                }
+            else:
+                sensor_dict = sensor_services.enrich_sensor(sensor)
+                sensor_dict["fields"] = [
+                    MonitoringSensorField.model_construct(**f.__dict__).model_dump()
+                    for f in sensor.fields
+                ]
+            sensors.append(sensor_dict)
+        source_dict["sensors"] = sensors
+        if minimal:
+            source_model = schemas.SourceWithSensorNames.model_construct(**source_dict)
+        else:
+            source_model = schemas.SourceWithSensors.model_construct(**source_dict)
+    else:
+        source_model = schemas.Source.model_construct(**source_dict)
+
     return source_model.model_dump()


### PR DESCRIPTION
## Summary
- add lightweight versions of sensor and field schemas
- expand Source endpoints to accept `minimal_children`
- enrich Source services to optionally return simplified sensor info

## Testing
- `python -m py_compile app/monitoring_source/services.py app/monitoring_source/apis.py app/monitoring_source/schemas.py app/monitoring_sensor/schemas.py app/monitoring_sensor_fields/schemas.py`


------
https://chatgpt.com/codex/tasks/task_e_68602eec942c832bbd0f393632210f26