### PR TITLE
Add minimal and full source endpoints

### DIFF
--- a/app/monitoring_sensor/schemas.py
+++ b/app/monitoring_sensor/schemas.py
@@ -1,5 +1,6 @@
-from pydantic import BaseModel
-from typing import Optional
+from pydantic import BaseModel, Field
+from typing import Optional, List
+from app.monitoring_sensor_fields.schemas import MonitoringSensorField, MonitoringSensorFieldName
 from uuid import UUID
 from datetime import datetime
 
@@ -31,3 +32,20 @@ class MonitoringSensor(MonitoringSensorBase):
 
     class Config:
         orm_mode = True
+
+
+class MonitoringSensorWithFields(MonitoringSensor):
+    fields: List[MonitoringSensorField] = Field(default_factory=list)
+
+
+class MonitoringSensorName(BaseModel):
+    id: UUID
+    sensor_name: str
+
+    class Config:
+        orm_mode = True
+
+
+class MonitoringSensorNameWithFields(MonitoringSensorName):
+    fields: List[MonitoringSensorFieldName] = Field(default_factory=list)
+

--- a/app/monitoring_sensor/services.py
+++ b/app/monitoring_sensor/services.py
@@ -29,7 +29,7 @@ def delete_monitoring_sensor(db: Session, sensor_id: UUID) -> None:
         db.delete(obj)
         db.commit()
 
-def enrich_sensor(sensor: MonitoringSensor) -> dict:
+def enrich_sensor(sensor: MonitoringSensor) -> schemas.MonitoringSensor:
     # if you later want more related data you can load it here
     # but at minimum we can pull source.source_name into a top‐level field:
     source_name = getattr(sensor.mon_source, "source_name", None)
@@ -41,4 +41,4 @@ def enrich_sensor(sensor: MonitoringSensor) -> dict:
 
     # Construct a Pydantic model without re‐validating
     model = schemas.MonitoringSensor.model_construct(**sensor_dict)
-    return model.model_dump()
+    return model

--- a/app/monitoring_sensor_fields/schemas.py
+++ b/app/monitoring_sensor_fields/schemas.py
@@ -24,3 +24,11 @@ class MonitoringSensorField(MonitoringSensorFieldBase):
 
     class Config:
         orm_mode = True
+
+
+class MonitoringSensorFieldName(BaseModel):
+    id: UUID
+    field_name: str
+
+    class Config:
+        orm_mode = True

--- a/app/monitoring_source/apis.py
+++ b/app/monitoring_source/apis.py
@@ -16,12 +16,50 @@ def list_sources(skip: int = 0, limit: int = 100, db: Session = Depends(get_db))
     sources = selectors.get_sources(db, skip, limit)
     return [services.enrich_source(src) for src in sources]
 
+
+@router.get("/with-children", response_model=List[schemas.SourceWithSensors])
+def list_sources_with_children(
+    skip: int = 0, limit: int = 100, db: Session = Depends(get_db)
+):
+    sources = selectors.get_sources(db, skip, limit)
+    return [services.enrich_source(src, True, False) for src in sources]
+
+
+@router.get(
+    "/with-minimal-children",
+    response_model=List[schemas.SourceWithSensorNames],
+)
+def list_sources_with_minimal_children(
+    skip: int = 0, limit: int = 100, db: Session = Depends(get_db)
+):
+    sources = selectors.get_sources(db, skip, limit)
+    return [services.enrich_source(src, True, True) for src in sources]
+
 @router.get("/{source_id}", response_model=schemas.Source)
 def get_source(source_id: UUID, db: Session = Depends(get_db)):
     src = selectors.get_source(db, source_id)
     if not src:
         raise HTTPException(status_code=404, detail="Source not found")
     return services.enrich_source(src)
+
+
+@router.get("/{source_id}/with-children", response_model=schemas.SourceWithSensors)
+def get_source_with_children(source_id: UUID, db: Session = Depends(get_db)):
+    src = selectors.get_source(db, source_id)
+    if not src:
+        raise HTTPException(status_code=404, detail="Source not found")
+    return services.enrich_source(src, True, False)
+
+
+@router.get(
+    "/{source_id}/with-minimal-children",
+    response_model=schemas.SourceWithSensorNames,
+)
+def get_source_with_minimal_children(source_id: UUID, db: Session = Depends(get_db)):
+    src = selectors.get_source(db, source_id)
+    if not src:
+        raise HTTPException(status_code=404, detail="Source not found")
+    return services.enrich_source(src, True, True)
 
 @router.patch("/{source_id}", response_model=schemas.Source)
 def update_source(source_id: UUID, payload: schemas.SourceUpdate, db: Session = Depends(get_db)):

--- a/app/monitoring_source/schemas.py
+++ b/app/monitoring_source/schemas.py
@@ -1,7 +1,11 @@
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List
 from uuid import UUID
 from datetime import datetime
+from app.monitoring_sensor.schemas import (
+    MonitoringSensorWithFields,
+    MonitoringSensorNameWithFields,
+)
 
 class SourceBase(BaseModel):
     mon_loc_id: Optional[UUID] = None
@@ -45,3 +49,11 @@ class Source(SourceBase):
 
     class Config:
         from_attributes  = True
+
+
+class SourceWithSensors(Source):
+    sensors: Optional[List[MonitoringSensorWithFields]] = None
+
+
+class SourceWithSensorNames(Source):
+    sensors: Optional[List[MonitoringSensorNameWithFields]] = None


### PR DESCRIPTION
## Summary
- ensure sensor schemas use `Field(default_factory=list)` to avoid mutable defaults
- return pydantic models from sensor and source service helpers
- split source list/get API into dedicated routes for child and minimal views

## Testing
- `python -m py_compile app/monitoring_source/services.py app/monitoring_source/apis.py app/monitoring_source/schemas.py app/monitoring_sensor/schemas.py app/monitoring_sensor_fields/schemas.py app/monitoring_sensor/services.py`


------
https://chatgpt.com/codex/tasks/task_e_68602eec942c832bbd0f393632210f26