### PR TITLE
Add source last-updated endpoint

### DIFF
--- a/app/monitoring_source/apis.py
+++ b/app/monitoring_source/apis.py
@@ -1,15 +1,19 @@
-from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.orm import Session
 from typing import List
 from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
 from app.common.dependencies import get_db
-from app.monitoring_source import schemas, services, selectors
+from app.monitoring_source import schemas, selectors, services
 
 router = APIRouter(prefix="/monitoring-sources", tags=["Monitoring Sources"])
+
 
 @router.post("/", response_model=schemas.Source, status_code=status.HTTP_201_CREATED)
 def create_source(payload: schemas.SourceCreate, db: Session = Depends(get_db)):
     return services.create_source(db, payload)
+
 
 @router.get("/", response_model=List[schemas.Source])
 def list_sources(
@@ -20,12 +24,24 @@ def list_sources(
     sources = selectors.get_sources(db, skip, limit)
     return [services.enrich_source(src, False, False) for src in sources]
 
+
+@router.get("/last-updated", response_model=List[schemas.SourceLastUpdated])
+def list_sources_last_updated(
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(get_db),
+):
+    rows = selectors.get_source_updates(db, skip, limit)
+    return [schemas.SourceLastUpdated(id=row[0], last_updated=row[1]) for row in rows]
+
+
 @router.get("/with-children", response_model=List[schemas.SourceWithSensors])
 def list_sources_with_children(
     skip: int = 0, limit: int = 100, db: Session = Depends(get_db)
 ):
     sources = selectors.get_sources(db, skip, limit)
     return [services.enrich_source(src, True, False) for src in sources]
+
 
 @router.get(
     "/with-minimal-children",
@@ -37,6 +53,7 @@ def list_sources_with_minimal_children(
     sources = selectors.get_sources(db, skip, limit)
     return [services.enrich_source(src, True, True) for src in sources]
 
+
 @router.get("/{source_id}", response_model=schemas.Source)
 def get_source(
     source_id: UUID,
@@ -47,6 +64,7 @@ def get_source(
         raise HTTPException(status_code=404, detail="Source not found")
     return services.enrich_source(src, False, False)
 
+
 @router.get("/{source_id}/with-children", response_model=schemas.SourceWithSensors)
 def get_source_with_children(source_id: UUID, db: Session = Depends(get_db)):
     src = selectors.get_source(db, source_id)
@@ -54,19 +72,26 @@ def get_source_with_children(source_id: UUID, db: Session = Depends(get_db)):
         raise HTTPException(status_code=404, detail="Source not found")
     return services.enrich_source(src, True, False)
 
-@router.get("/{source_id}/with-minimal-children", response_model=schemas.SourceWithSensorNames)
+
+@router.get(
+    "/{source_id}/with-minimal-children", response_model=schemas.SourceWithSensorNames
+)
 def get_source_with_minimal_children(source_id: UUID, db: Session = Depends(get_db)):
     src = selectors.get_source(db, source_id)
     if not src:
         raise HTTPException(status_code=404, detail="Source not found")
     return services.enrich_source(src, True, True)
 
+
 @router.patch("/{source_id}", response_model=schemas.Source)
-def update_source(source_id: UUID, payload: schemas.SourceUpdate, db: Session = Depends(get_db)):
+def update_source(
+    source_id: UUID, payload: schemas.SourceUpdate, db: Session = Depends(get_db)
+):
     obj = services.update_source(db, source_id, payload)
     if not obj:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Source not found")
     return obj
+
 
 @router.delete("/{source_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_source(source_id: UUID, db: Session = Depends(get_db)):

--- a/app/monitoring_source/schemas.py
+++ b/app/monitoring_source/schemas.py
@@ -1,11 +1,14 @@
-from pydantic import BaseModel
-from typing import Optional, List
-from uuid import UUID
 from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
 from app.monitoring_sensor.schemas import (
-    MonitoringSensorWithFields,
     MonitoringSensorNameWithFields,
+    MonitoringSensorWithFields,
 )
+
 
 class SourceBase(BaseModel):
     mon_loc_id: Optional[UUID] = None
@@ -18,8 +21,10 @@ class SourceBase(BaseModel):
     last_data_upload: Optional[str] = None
     active: Optional[int] = 1
 
+
 class SourceCreate(SourceBase):
     pass
+
 
 class SourceUpdate(BaseModel):
     mon_loc_id: Optional[UUID] = None
@@ -32,6 +37,7 @@ class SourceUpdate(BaseModel):
     last_data_upload: Optional[str] = None
     active: Optional[int] = None
 
+
 class SourceMetadata(BaseModel):
     loc_number: Optional[str] = None
     loc_name: str
@@ -40,7 +46,8 @@ class SourceMetadata(BaseModel):
     project_name: str
 
     class Config:
-        from_attributes  = True
+        from_attributes = True
+
 
 class Source(SourceBase):
     id: UUID
@@ -48,7 +55,7 @@ class Source(SourceBase):
     details: Optional[SourceMetadata] = None
 
     class Config:
-        from_attributes  = True
+        from_attributes = True
 
 
 class SourceWithSensors(Source):
@@ -57,3 +64,13 @@ class SourceWithSensors(Source):
 
 class SourceWithSensorNames(Source):
     sensors: Optional[List[MonitoringSensorNameWithFields]] = None
+
+
+class SourceLastUpdated(BaseModel):
+    """Schema exposing only the id and last_updated fields of a Source."""
+
+    id: UUID
+    last_updated: datetime
+
+    class Config:
+        from_attributes = True

--- a/app/monitoring_source/selectors.py
+++ b/app/monitoring_source/selectors.py
@@ -1,8 +1,10 @@
-from app.monitoring_source.models import Source
-from app.location.models import Location
-from sqlalchemy.orm import Session, joinedload
 from typing import Optional
 from uuid import UUID
+
+from sqlalchemy.orm import Session, joinedload
+
+from app.location.models import Location
+from app.monitoring_source.models import Source
 
 
 def get_source(db: Session, source_id: UUID) -> Optional[Source]:
@@ -13,6 +15,7 @@ def get_source(db: Session, source_id: UUID) -> Optional[Source]:
         .first()
     )
 
+
 def get_sources(db: Session, skip: int = 0, limit: int = 100) -> list[type[Source]]:
     return (
         db.query(Source)
@@ -21,3 +24,9 @@ def get_sources(db: Session, skip: int = 0, limit: int = 100) -> list[type[Sourc
         .limit(limit)
         .all()
     )
+
+
+def get_source_updates(db: Session, skip: int = 0, limit: int = 100):
+    """Return only the id and last_updated fields for all sources."""
+
+    return db.query(Source.id, Source.last_updated).offset(skip).limit(limit).all()


### PR DESCRIPTION
## Summary
- add `SourceLastUpdated` schema for minimal source data
- implement selector helper `get_source_updates`
- expose `/monitoring-sources/last-updated` endpoint to retrieve only source UUID and last_updated

## Testing
- `black -q app/monitoring_source/apis.py app/monitoring_source/schemas.py app/monitoring_source/selectors.py`
- `isort app/monitoring_source/apis.py app/monitoring_source/schemas.py app/monitoring_source/selectors.py`

------
https://chatgpt.com/codex/tasks/task_e_68668ebafac8832b9d0dac4880ce672b