### PR TITLE
Add query endpoint for monitoring sensor data

### DIFF
--- a/app/monitoring_sensor_data/apis.py
+++ b/app/monitoring_sensor_data/apis.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, status
-from typing import List
+from typing import List, Optional
 from datetime import datetime
 from uuid import UUID
 from sqlalchemy.orm import Session
@@ -22,6 +22,35 @@ def list_monitoring_sensor_data(
     db: Session = Depends(get_db),
 ):
     return selectors.get_monitoring_sensor_data_list(db, skip=skip, limit=limit)
+
+
+@router.get("/query", response_model=List[schemas.MonitoringSensorDataQueryResult])
+def query_monitoring_sensor_data(
+    project_id: Optional[UUID] = None,
+    location_id: Optional[UUID] = None,
+    sensor_id: Optional[UUID] = None,
+    sensor_type: Optional[str] = None,
+    sensor_group_id: Optional[UUID] = None,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    aggregate_period: Optional[str] = None,
+    trim_percentile_low: Optional[float] = None,
+    trim_percentile_high: Optional[float] = None,
+    db: Session = Depends(get_db),
+):
+    return selectors.query_monitoring_sensor_data(
+        db,
+        project_id=project_id,
+        location_id=location_id,
+        sensor_id=sensor_id,
+        sensor_type=sensor_type,
+        sensor_group_id=sensor_group_id,
+        start=start,
+        end=end,
+        aggregate_period=aggregate_period,
+        trim_low=trim_percentile_low,
+        trim_high=trim_percentile_high,
+    )
 
 @router.get("/{sensor_field_id}/{timestamp}", response_model=schemas.MonitoringSensorData)
 def get_monitoring_sensor_data(sensor_field_id: UUID, timestamp: datetime, db: Session = Depends(get_db)):

--- a/app/monitoring_sensor_data/schemas.py
+++ b/app/monitoring_sensor_data/schemas.py
@@ -45,3 +45,14 @@ class BulkSensorDataItem(BaseModel):
 
 class MonitoringSensorDataBulkRequest(BaseModel):
     items: List[BulkSensorDataItem]
+
+
+# Response model for queried/aggregated sensor data
+class MonitoringSensorDataQueryResult(BaseModel):
+    timestamp: datetime
+    sensor_id: UUID
+    sensor_field_id: UUID
+    data: float
+
+    class Config:
+        orm_mode = True

--- a/app/monitoring_sensor_data/selectors.py
+++ b/app/monitoring_sensor_data/selectors.py
@@ -1,8 +1,16 @@
 from typing import List, Optional
 from sqlalchemy.orm import Session
+from sqlalchemy import func, and_
 from datetime import datetime
 from uuid import UUID
+
 from app.monitoring_sensor_data.models import MonitoringSensorData
+from app.monitoring_sensor.models import MonitoringSensor
+from app.monitoring_sensor_fields.models import MonitoringSensorField
+from app.monitoring_group.models import MonitoringGroup
+from app.monitoring_source.models import Source
+from app.location.models import Location
+from app.project.models import Project
 
 def get_monitoring_sensor_data_entry(db: Session, sensor_field_id: UUID, timestamp: datetime) -> Optional[MonitoringSensorData]:
     return db.query(MonitoringSensorData).filter(
@@ -12,3 +20,90 @@ def get_monitoring_sensor_data_entry(db: Session, sensor_field_id: UUID, timesta
 
 def get_monitoring_sensor_data_list(db: Session, skip: int = 0, limit: int = 100) -> List[MonitoringSensorData]:
     return db.query(MonitoringSensorData).offset(skip).limit(limit).all()
+
+
+def query_monitoring_sensor_data(
+    db: Session,
+    *,
+    project_id: Optional[UUID] = None,
+    location_id: Optional[UUID] = None,
+    sensor_id: Optional[UUID] = None,
+    sensor_type: Optional[str] = None,
+    sensor_group_id: Optional[UUID] = None,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    aggregate_period: Optional[str] = None,
+    trim_low: Optional[float] = None,
+    trim_high: Optional[float] = None,
+) -> List[MonitoringSensorData]:
+    """Query sensor data with optional filters and aggregation."""
+
+    q = db.query(MonitoringSensorData)
+    q = q.join(MonitoringSensor, MonitoringSensorData.sensor_id == MonitoringSensor.id)
+    q = q.join(MonitoringSensorField, MonitoringSensorData.sensor_field_id == MonitoringSensorField.id)
+    q = q.join(Source, MonitoringSensor.mon_source_id == Source.id)
+    q = q.join(Location, Source.mon_loc_id == Location.id)
+    q = q.join(Project, Location.project_id == Project.id)
+    q = q.outerjoin(MonitoringGroup, MonitoringSensor.sensor_group_id == MonitoringGroup.id)
+
+    if project_id:
+        q = q.filter(Project.id == project_id)
+    if location_id:
+        q = q.filter(Location.id == location_id)
+    if sensor_id:
+        q = q.filter(MonitoringSensor.id == sensor_id)
+    if sensor_type:
+        q = q.filter(MonitoringSensor.sensor_type == sensor_type)
+    if sensor_group_id:
+        q = q.filter(MonitoringGroup.id == sensor_group_id)
+    if start:
+        q = q.filter(MonitoringSensorData.timestamp >= start)
+    if end:
+        q = q.filter(MonitoringSensorData.timestamp <= end)
+
+    if trim_low is not None or trim_high is not None:
+        lp = (trim_low or 0) / 100
+        hp = (trim_high or 100) / 100
+        bounds = (
+            q.with_entities(
+                MonitoringSensorData.sensor_id.label("s_id"),
+                MonitoringSensorData.sensor_field_id.label("f_id"),
+                func.percentile_cont(lp).within_group(MonitoringSensorData.data).label("low_val"),
+                func.percentile_cont(hp).within_group(MonitoringSensorData.data).label("high_val"),
+            )
+            .group_by(MonitoringSensorData.sensor_id, MonitoringSensorData.sensor_field_id)
+            .subquery()
+        )
+        q = q.join(
+            bounds,
+            and_(
+                bounds.c.s_id == MonitoringSensorData.sensor_id,
+                bounds.c.f_id == MonitoringSensorData.sensor_field_id,
+            ),
+        )
+        q = q.filter(
+            MonitoringSensorData.data >= bounds.c.low_val,
+            MonitoringSensorData.data <= bounds.c.high_val,
+        )
+
+    if aggregate_period:
+        ts = func.date_trunc(aggregate_period, MonitoringSensorData.timestamp).label("timestamp")
+        q = (
+            q.with_entities(
+                ts,
+                MonitoringSensorData.sensor_id,
+                MonitoringSensorData.sensor_field_id,
+                func.avg(MonitoringSensorData.data).label("data"),
+            )
+            .group_by(ts, MonitoringSensorData.sensor_id, MonitoringSensorData.sensor_field_id)
+            .order_by(ts)
+        )
+    else:
+        q = q.with_entities(
+            MonitoringSensorData.timestamp.label("timestamp"),
+            MonitoringSensorData.sensor_id,
+            MonitoringSensorData.sensor_field_id,
+            MonitoringSensorData.data.label("data"),
+        ).order_by(MonitoringSensorData.timestamp)
+
+    return q.all()


### PR DESCRIPTION
## Summary
- add `MonitoringSensorDataQueryResult` schema
- implement flexible `query_monitoring_sensor_data` selector to filter, aggregate, and trim results
- expose new `/monitoring-sensor-data/query` endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687bb40e7578832b9b8f5f1cbf2f5dcf