### PR TITLE
Fix sensor query field name output

### DIFF
--- a/app/monitoring_sensor_data/apis.py
+++ b/app/monitoring_sensor_data/apis.py
@@ -132,7 +132,7 @@ def query_monitoring_sensor_data(
         aggregate_period=aggregate_period,
         trim_percentile_low=trim_percentile_low,
         trim_percentile_high=trim_percentile_high,
-        include_field_name=False,
+        include_field_name=True,
         output=output,
         db=db,
     )

--- a/tests/test_sensor_data_query_names.py
+++ b/tests/test_sensor_data_query_names.py
@@ -82,3 +82,4 @@ def test_query_includes_names(client, db):
     assert item["sensor_name"] == "s1"
     assert item["project_name"] == "Proj"
     assert item["location_name"] == "Loc"
+    assert item["field_name"] == "temp"


### PR DESCRIPTION
## Summary
- include `field_name` in `/query-by-field` results
- test for presence of field names in sensor data queries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688243891958832bb3f70af57b8cce0d