### PR TITLE
Add limit parameter to monitoring source selectors

### DIFF
--- a/app/monitoring_source/selectors.py
+++ b/app/monitoring_source/selectors.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 from uuid import UUID
 
 from sqlalchemy.orm import Session, joinedload
@@ -16,12 +16,15 @@ def get_source(db: Session, source_id: UUID) -> Optional[Source]:
     )
 
 
-def get_sources(db: Session, skip: int = 0) -> list[type[Source]]:
+def get_sources(
+    db: Session, skip: int = 0, limit: int = 100
+) -> List[Source]:
     return (
         db.query(Source)
         .options(joinedload(Source.mon_loc).joinedload(Location.project))
         .order_by(Source.source_name)
         .offset(skip)
+        .limit(limit)
         .all()
     )
 


### PR DESCRIPTION
## Summary
- add limit parameter to `get_sources`

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'app')

------
https://chatgpt.com/codex/tasks/task_e_68b753ade16c832ba4a81b6a843dd8bc